### PR TITLE
Remove colorless output

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,6 +19,10 @@ Use `Ctrl-C` to stop a running instance of `dali_mon`.
     0.006 |    0.001 | ERROR: SYSTEM FAILURE
     0.007 |    0.001 | ERROR: SYSTEM RECOVER
 
+You can remove the colour control codes from the output stream using `ansifilter`.
+
+    ./dali_mon < tests/sample.txt | ansifilter
+
 ## Read from Serial Port
 
 Remember to set the serial port communication parammeters before starting the monitor routine. This example reads from a serial port connected to `ttyUSB0` using a baudrate of 115200 Baud.
@@ -32,7 +36,6 @@ Remember to set the serial port communication parammeters before starting the mo
 |-----------|-------|-----------------------------------------------------|
 |--help     |       | Show help message and exit.                         |
 |--version  |       | Show the version information and exit.              |
-|--nocolor  |       | Do not use color coding for output.                 |
 |--absolute |       | Add absolute time from host machine to output.      |
 |--echo     |       | Echo unprocessed input line to output.              |
 |--hid      | -l    | Use HID class USB connector for DALI communication. |

--- a/source/DALI/decode.py
+++ b/source/DALI/decode.py
@@ -6,7 +6,7 @@ from .forward_frame_32bit import ForwardFrame32Bit
 
 
 class Decode:
-    ADDRESS_WIDTH = 12
+    ADDRESS_WIDTH = 14
     DATA_WIDTH = 8
 
     def __init__(self, length, data, device_type=DeviceType.NONE):

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -96,7 +96,7 @@ def main_file(transparent, absolute_time):
 def dali_mon(hid, debug, nocolor, echo, absolute):
     """
     Monitor for DALI commands,
-    SevenLabs 2023
+    SevenLab 2023
     """
     if debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -93,7 +93,7 @@ def main_file(transparent, absolute_time):
 @click.option("--debug", help="Enable debug level logging.", is_flag=True)
 @click.option("--echo", help="Echo unprocessed input line to output.", is_flag=True)
 @click.option("--absolute", help="Add absolute local time to output.", is_flag=True)
-def dali_mon(hid, debug, nocolor, echo, absolute):
+def dali_mon(hid, debug, echo, absolute):
     """
     Monitor for DALI commands,
     SevenLab 2023

--- a/source/dali_mon.py
+++ b/source/dali_mon.py
@@ -12,43 +12,27 @@ from connection.hid import DaliUsb
 logger = logging.getLogger(__name__)
 
 
-def print_local_time_color(enabled):
+def print_local_time(enabled):
     if enabled:
         time_string = datetime.now().strftime("%H:%M:%S")
         cprint(f"{time_string} | ", color="yellow", end="")
 
 
-def print_local_time(enabled):
-    if enabled:
-        time_string = datetime.now().strftime("%H:%M:%S")
-        print(f"{time_string} | ", end="")
-
-
-def print_command_color(absolute_time, timestamp, delta, dali_command):
-    print_local_time_color(absolute_time)
+def print_command(absolute_time, timestamp, delta, dali_command):
+    print_local_time(absolute_time)
     cprint(
         f"{timestamp:.03f} | {delta:8.03f} | {dali_command} | ", color="green", end=""
     )
     cprint(f"{dali_command.cmd()}", color="white")
 
 
-def print_command(absolute_time, timestamp, delta, dali_command):
+def print_error(absolute_time, timestamp, delta, status):
     print_local_time(absolute_time)
-    print(f"{timestamp:.03f} | {delta:8.03f} | {dali_command} | {dali_command.cmd()}")
-
-
-def print_error_color(absolute_time, timestamp, delta, status):
-    print_local_time_color(absolute_time)
     cprint(f"{timestamp:.03f} | {delta:8.03f} | ", color="green", end="")
     cprint(f"{status.message}", color="red")
 
 
-def print_error(absolute_time, timestamp, delta, status):
-    print_local_time(absolute_time)
-    print(f"{timestamp:.03f} | {delta:8.03f} | {status.message}")
-
-
-def process_line(frame, no_color, absolute_time):
+def process_line(frame, absolute_time):
     if process_line.last_timestamp != 0:
         delta = frame.timestamp - process_line.last_timestamp
     else:
@@ -57,33 +41,27 @@ def process_line(frame, no_color, absolute_time):
         dali_command = DALI.Decode(
             frame.length, frame.data, process_line.active_device_type
         )
-        if no_color:
-            print_command(absolute_time, frame.timestamp, delta, dali_command)
-        else:
-            print_command_color(absolute_time, frame.timestamp, delta, dali_command)
-            process_line.active_device_type = dali_command.get_next_device_type()
+        print_command(absolute_time, frame.timestamp, delta, dali_command)
+        process_line.active_device_type = dali_command.get_next_device_type()
     else:
-        if no_color:
-            print_error(absolute_time, frame.timestamp, delta, frame.status)
-        else:
-            print_error_color(absolute_time, frame.timestamp, delta, frame.status)
+        print_error(absolute_time, frame.timestamp, delta, frame.status)
     process_line.last_timestamp = frame.timestamp
 
 
-def main_usb(no_color, absolute_time):
+def main_usb(absolute_time):
     logger.debug("read from Lunatone usb device")
     dali_connection = DaliUsb()
     dali_connection.start_receive()
     try:
         while True:
             dali_connection.get_next()
-            process_line(dali_connection.rx_frame, no_color, absolute_time)
+            process_line(dali_connection.rx_frame, absolute_time)
     except KeyboardInterrupt:
         print("\rinterrupted")
         dali_connection.close()
 
 
-def main_tty(transparent, no_color, absolute_time):
+def main_tty(transparent, absolute_time):
     logger.debug("read from tty device")
     line = ""
     while True:
@@ -92,20 +70,20 @@ def main_tty(transparent, no_color, absolute_time):
             line = line.strip(" \r\n")
             if len(line) > 0:
                 frame = DaliSerial.parse(line.encode("utf-8"))
-                process_line(frame, no_color, absolute_time)
+                process_line(frame, absolute_time)
             line = ""
 
 
-def main_file(transparent, no_color, absolute_time):
+def main_file(transparent, absolute_time):
     logger.debug("read from file")
     for line in sys.stdin:
         if len(line) > 0:
             frame = DaliSerial.parse(line.encode("utf-8"))
-            process_line(frame, no_color, absolute_time)
+            process_line(frame, absolute_time)
 
 
 @click.command()
-@click.version_option("1.3.0")
+@click.version_option("1.4.0")
 @click.option(
     "-l",
     "--hid",
@@ -113,7 +91,6 @@ def main_file(transparent, no_color, absolute_time):
     is_flag=True,
 )
 @click.option("--debug", help="Enable debug level logging.", is_flag=True)
-@click.option("--nocolor", help="Do not use color coding for output.", is_flag=True)
 @click.option("--echo", help="Echo unprocessed input line to output.", is_flag=True)
 @click.option("--absolute", help="Add absolute local time to output.", is_flag=True)
 def dali_mon(hid, debug, nocolor, echo, absolute):
@@ -128,11 +105,11 @@ def dali_mon(hid, debug, nocolor, echo, absolute):
     process_line.active_device_type = DALI.DeviceType.NONE
     try:
         if hid:
-            main_usb(nocolor, absolute)
+            main_usb(absolute)
         elif sys.stdin.isatty():
-            main_tty(echo, nocolor, absolute)
+            main_tty(echo, absolute)
         else:
-            main_file(echo, nocolor, absolute)
+            main_file(echo, absolute)
     except KeyboardInterrupt:
         print("\rinterrupted")
 

--- a/source/tests/mon/test_102.py
+++ b/source/tests/mon/test_102.py
@@ -1,7 +1,7 @@
 import pytest
 import DALI
 
-ADDRESS_WIDTH = 12
+ADDRESS_WIDTH = 14
 
 
 def test_backframe():

--- a/source/tests/mon/test_103.py
+++ b/source/tests/mon/test_103.py
@@ -1,7 +1,7 @@
 import pytest
 import DALI
 
-ADDRESS_WIDTH = 12
+ADDRESS_WIDTH = 14
 
 
 # refer to iec62386 103 Table 21

--- a/source/tests/mon/test_105.py
+++ b/source/tests/mon/test_105.py
@@ -1,7 +1,7 @@
 import pytest
 import DALI
 
-ADDRESS_WIDTH = 12
+ADDRESS_WIDTH = 14
 
 
 def build_firmware_frame(

--- a/source/tests/mon/test_207.py
+++ b/source/tests/mon/test_207.py
@@ -1,7 +1,7 @@
 import pytest
 import DALI
 
-ADDRESS_WIDTH = 12
+ADDRESS_WIDTH = 14
 
 
 # refer to iec62386 207 Table 6

--- a/source/tests/mon/test_serial.py
+++ b/source/tests/mon/test_serial.py
@@ -1,34 +1,35 @@
+from connection.status import DaliStatus
 from connection.serial import DaliSerial
 
 
 def test_raw_from_string():
     input_string = "{00000000:08 000011}".encode("utf-8")
     result = DaliSerial.parse(input_string)
-    assert result[0] == 0
-    assert result[1] is False
-    assert result[2] == 0x8
-    assert result[3] == 0x11
+    assert result.timestamp == 0
+    assert result.length == 0x8
+    assert result.data == 0x11
+    assert result.status.status == DaliStatus.FRAME
     input_string = "{00000001:10 0000FF00}".encode("utf-8")
     result = DaliSerial.parse(input_string)
-    assert result[0] == 0.001
-    assert result[1] is False
-    assert result[2] == 0x10
-    assert result[3] == 0xFF00
+    assert result.timestamp == 0.001
+    assert result.length == 0x10
+    assert result.data == 0xFF00
+    assert result.status.status == DaliStatus.FRAME
     input_string = "{00000002:18 00123456}".encode("utf-8")
     result = DaliSerial.parse(input_string)
-    assert result[0] == 0.002
-    assert result[1] is False
-    assert result[2] == 0x18
-    assert result[3] == 0x123456
+    assert result.timestamp == 0.002
+    assert result.length == 0x18
+    assert result.data == 0x123456
+    assert result.status.status == DaliStatus.FRAME
     input_string = "{00000003:83 00123456}".encode("utf-8")
     result = DaliSerial.parse(input_string)
-    assert result[0] == 0.003
-    assert result[1] is False
-    assert result[2] == 0x83
-    assert result[3] == 0x123456
+    assert result.timestamp == 0.003
+    assert result.length == 0x83
+    assert result.data == 0x123456
+    assert result.status.status == DaliStatus.TIMING
     input_string = "{00000004:20 87654321}".encode("utf-8")
     result = DaliSerial.parse(input_string)
-    assert result[0] == 0.004
-    assert result[1] is False
-    assert result[2] == 0x20
-    assert result[3] == 0x87654321
+    assert result.timestamp == 0.004
+    assert result.length == 0x20
+    assert result.data == 0x87654321
+    assert result.status.status == DaliStatus.FRAME


### PR DESCRIPTION
Don´t implement color-less output messages in this code. This functionality is achievable with standard command line tooling. So keep this code as simple as possible.